### PR TITLE
Changes command to run pytest

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -194,11 +194,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:16923d366ced322712c71ccb97164d07472abeecd13f3a6c283f6d5d26722793",
-                "sha256:db3b8e2f922b2a910a29804776c643ea609badb6a32c4bcc226fd4fd902cce65"
+                "sha256:0d33c374d41c7863419fc8f6c10bfe25b7b498aa34164d135c622e52580c6b16",
+                "sha256:c04b44a57a6265fe34a4a444e965884716d34bae963119a76353434d6f18e450"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==63.1.0"
+            "version": "==63.2.0"
         },
         "six": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ TypeError: can only concatenate str (not "int") to str
 
 ## Instructions
 
-To get started, run `pytest -x` to run the first test in the test suite.
+To get started, run `pipenv run pytest -x` to run the first test in the test suite.
 Use the error messages to guide your work:
 
 - Read the errors. Scroll through the entire output to get a sense of what the

--- a/lib/a_name_error.py
+++ b/lib/a_name_error.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
-
+hello_world = "hi there"
 print(hello_world)

--- a/lib/a_syntax_error.py
+++ b/lib/a_syntax_error.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-poor_syntax = 2 * #
+poor_syntax = 2 * 4

--- a/lib/a_type_error.py
+++ b/lib/a_type_error.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-wrong_type = 'abc' + 123
+wrong_type = 3 + 123

--- a/lib/an_assertion_error.py
+++ b/lib/an_assertion_error.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python3
 
-assert(1 == 2)
+assert(1 == 1)


### PR DESCRIPTION
Hey folks. I wasn't able to run pytest -x after running pipenv install in the lab directory. pytest is not installed globally and therefore is not in my path. The only way I was able to get pytest to execute was by spawning the command installed in the virtualenv with `pipenv run pytest -x`.